### PR TITLE
Add databricks-otel plugin for automatic OTEL telemetry export

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,6 +58,16 @@
         "name": "AI engineering"
       },
       "category": "mcp-servers"
+    },
+    {
+      "name": "icerhymers-databricks-otel",
+      "source": "./plugins/databricks-otel",
+      "description": "Auto-configures Claude Code OTEL telemetry export to a shared Databricks table",
+      "version": "1.0.0",
+      "author": {
+        "name": "AI engineering"
+      },
+      "category": "observability"
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ PLUGINS := \
 	icerhymers-internal-skills \
 	icerhymers-marketplace-management \
 	icerhymers-specialized-tools \
-	icerhymers-databricks-mcp
+	icerhymers-databricks-mcp \
+	icerhymers-databricks-otel
 
 MARKETPLACE := icerhymers-marketplace
 

--- a/plugins/databricks-otel/.claude-plugin/plugin.json
+++ b/plugins/databricks-otel/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "icerhymers-databricks-otel",
+  "description": "Auto-configures Claude Code OTEL telemetry export to a shared Databricks table",
+  "version": "1.0.0",
+  "author": { "name": "AI engineering" },
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup-otel-env.sh"
+      }]
+    }]
+  }
+}

--- a/plugins/databricks-otel/scripts/setup-otel-env.sh
+++ b/plugins/databricks-otel/scripts/setup-otel-env.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Require Databricks auth — skip silently if not configured
+if [ -z "${DATABRICKS_HOST:-}" ] || [ -z "${DATABRICKS_TOKEN:-}" ] || [ -z "${CLAUDE_ENV_FILE:-}" ]; then
+  exit 0
+fi
+
+# Shared destination — override via CLAUDE_OTEL_UC_TABLE env var if needed
+UC_TABLE="${CLAUDE_OTEL_UC_TABLE:-main.claude_telemetry.claude_otel_metrics}"
+
+# Strip trailing slash from host
+DB_HOST="${DATABRICKS_HOST%/}"
+
+cat >> "$CLAUDE_ENV_FILE" <<EOF
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=${DB_HOST}/api/2.0/otel/v1/metrics
+export OTEL_EXPORTER_OTLP_METRICS_HEADERS=content-type=application/x-protobuf,Authorization=Bearer ${DATABRICKS_TOKEN},X-Databricks-UC-Table-Name=${UC_TABLE}
+EOF
+
+exit 0

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -104,6 +104,7 @@ FILES_TO_REPLACE=(
   "plugins/databricks-mcp/.claude-plugin/plugin.json"
   "plugins/databricks-mcp/.mcp.json"
   "plugins/databricks-mcp/skills/mcp-setup/SKILL.md"
+  "plugins/databricks-otel/.claude-plugin/plugin.json"
   "scripts/install.sh"
   "scripts/update.sh"
   "docs/INSTALL.md"


### PR DESCRIPTION
SessionStart hook auto-configures Claude Code OTEL metrics export to a shared Databricks UC table when DATABRICKS_HOST and DATABRICKS_TOKEN are set. No additional user setup required.