### PR TITLE
Improve pricing accuracy with per-model input/output token rates

### DIFF
--- a/.claude/skills/update-pricing/SKILL.md
+++ b/.claude/skills/update-pricing/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: update-pricing
+description: >
+  Refresh the static pricing table in usage-limits/app/core/pricing.py with current
+  Databricks pay-per-token model rates. Use when new models are added, pricing changes,
+  or coverage needs expanding beyond Claude to GPT, Gemini, Llama, etc.
+user-invocable: true
+allowed-tools: Read, Bash, Grep, Glob, Write, Edit
+---
+
+# Update Pricing
+
+Refreshes the per-token pricing data used by the usage-limits app to calculate dollar costs.
+
+## Prerequisites
+
+- Chrome DevTools MCP configured (for scraping the pricing page)
+- Databricks CLI authenticated (for discovering workspace models)
+- SQL warehouse ID available (via `SQL_WAREHOUSE_ID` env var or user input)
+
+## Workflow
+
+### Step 1: Scrape current pricing
+
+Use Chrome DevTools MCP to extract per-token rates from **two** Databricks pricing pages:
+
+**Page 1 — Proprietary models** (Claude, GPT, Gemini):
+1. Navigate to `https://www.databricks.com/product/pricing/proprietary-foundation-model-serving`
+2. Wait for the DBU rates table to render
+3. Use the "Select model vendor" dropdown to cycle through: **OpenAI**, **Anthropic**, **Google**
+4. For each vendor, take a snapshot and extract: model name, Input DBU/1M tokens, Output DBU/1M tokens
+5. Use Global endpoint and Short Context rates as the default
+
+**Page 2 — Open-source models** (Llama, Gemma, GPT OSS):
+1. Navigate to `https://www.databricks.com/product/pricing/foundation-model-serving`
+2. The DBU rates table is at the bottom — extract Input/Output DBU/1M tokens per model
+3. Skip models with "n/a" pay-per-token rates (PT-only or embedding-only)
+
+**Convert rates**: DBU/1M tokens → DBU/token = value / 1,000,000
+**Normalize names**: Add `databricks-` prefix, lowercase, spaces to hyphens (use `normalize_model_name()` from `scripts/scrape_pricing.py`)
+
+### Step 2: Discover workspace models
+
+Run the discovery script to find all pay-per-token models in use:
+
+```bash
+cd .claude/skills/update-pricing
+python scripts/discover_models.py --warehouse-id <WAREHOUSE_ID>
+```
+
+This outputs JSON with `discovered_models`, `available_endpoints`, `models_with_pricing`, and `models_missing_pricing`.
+
+### Step 3: Review gaps
+
+Present any `models_missing_pricing` to the user. For each:
+- Check if pricing was found in the scrape (Step 1)
+- If not, ask the user for manual input or mark as $0 cost
+
+### Step 4: Generate updated code
+
+Option A — Use the generator script:
+```bash
+python scripts/generate_pricing.py > /tmp/pricing_preview.py
+```
+
+Option B — Manually update `references/pricing_reference.py` with new rates, then regenerate.
+
+### Step 5: Apply
+
+Write the generated code to `usage-limits/app/core/pricing.py`.
+
+### Step 6: Update reference
+
+Ensure `references/pricing_reference.py` reflects all current rates:
+```bash
+python scripts/generate_pricing.py --update-reference scraped_data.json
+```
+
+### Step 7: Update tests
+
+If new model families were added, update `test_pricing_cte_contains_non_claude_models` in `usage-limits/app/tests/unit/test_pricing.py` to assert the new models are present.
+
+### Step 8: Verify
+
+```bash
+cd usage-limits && make test
+```
+
+All tests must pass.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `usage-limits/app/core/pricing.py` | Production pricing CTE + query |
+| `references/pricing_reference.py` | Source of truth for per-token rates |
+| `scripts/discover_models.py` | Find models in the workspace |
+| `scripts/scrape_pricing.py` | Scraping helpers + documentation |
+| `scripts/generate_pricing.py` | Code generation from reference data |
+| `usage-limits/app/tests/unit/test_pricing.py` | Pricing unit tests |

--- a/.claude/skills/update-pricing/references/pricing_reference.py
+++ b/.claude/skills/update-pricing/references/pricing_reference.py
@@ -1,0 +1,47 @@
+"""Reference pricing for Databricks pay-per-token models.
+
+Updated: 2026-03-06
+Source (proprietary): https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+Source (open-source): https://www.databricks.com/product/pricing/foundation-model-serving
+
+Keys are endpoint_name values from system.ai_gateway.usage.
+Values are (dbu_per_input_token, dbu_per_output_token).
+Rates use Global endpoint pricing and Short Context where applicable.
+"""
+
+PRICING: dict[str, tuple[float, float]] = {
+    # Anthropic — Claude
+    "databricks-claude-opus-4-6": (0.000071429, 0.000357143),
+    "databricks-claude-opus-4-5": (0.000071429, 0.000357143),
+    "databricks-claude-opus-4-1": (0.000214286, 0.001071429),
+    "databricks-claude-opus-4": (0.000214286, 0.001071429),
+    "databricks-claude-sonnet-4-6": (0.000042857, 0.000214286),
+    "databricks-claude-sonnet-4-5": (0.000042857, 0.000214286),
+    "databricks-claude-sonnet-4-1": (0.000042857, 0.000214286),
+    "databricks-claude-sonnet-4": (0.000042857, 0.000214286),
+    "databricks-claude-sonnet-3-7": (0.000042857, 0.000214286),
+    "databricks-claude-haiku-4-5": (0.000014286, 0.000071429),
+    # OpenAI — GPT
+    "databricks-gpt-5-2": (0.000025000, 0.000200000),
+    "databricks-gpt-5-1": (0.000017857, 0.000142857),
+    "databricks-gpt-5-1-codex-max": (0.000017857, 0.000142857),
+    "databricks-gpt-5": (0.000017857, 0.000142857),
+    "databricks-gpt-5-mini": (0.000003571, 0.000028571),
+    "databricks-gpt-5-1-codex-mini": (0.000003571, 0.000028571),
+    "databricks-gpt-5-nano": (0.000000714, 0.000005714),
+    # Google — Gemini
+    "databricks-gemini-3-0-pro": (0.000035714, 0.000214286),
+    "databricks-gemini-3-1-pro": (0.000035714, 0.000214286),
+    "databricks-gemini-3-0-flash": (0.000008929, 0.000053571),
+    "databricks-gemini-2-5-pro": (0.000017857, 0.000142857),
+    "databricks-gemini-2-5-flash": (0.000004286, 0.000035714),
+    # Open-source — Llama
+    "databricks-llama-4-maverick": (0.000007143, 0.000021429),
+    "databricks-llama-3-3-70b": (0.000007143, 0.000021429),
+    "databricks-llama-3-1-8b": (0.000002143, 0.000006429),
+    # Open-source — GPT OSS
+    "databricks-gpt-oss-120b": (0.000002143, 0.000008571),
+    "databricks-gpt-oss-20b": (0.000001000, 0.000004286),
+    # Open-source — Gemma
+    "databricks-gemma-3-12b": (0.000002143, 0.000007143),
+}

--- a/.claude/skills/update-pricing/scripts/discover_models.py
+++ b/.claude/skills/update-pricing/scripts/discover_models.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Discover pay-per-token models from a Databricks workspace.
+
+Queries system.ai_gateway.usage and serving endpoints to find all models,
+then cross-references with pricing_reference.py to identify gaps.
+
+Usage:
+    python discover_models.py --warehouse-id <WAREHOUSE_ID>
+
+Output: JSON to stdout with discovered models, available endpoints,
+        and pricing coverage gaps.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from databricks.sdk import WorkspaceClient
+
+
+def load_pricing_reference() -> dict[str, tuple[float, float]]:
+    """Load the pricing reference dict."""
+    ref_path = Path(__file__).parent.parent / "references" / "pricing_reference.py"
+    namespace: dict = {}
+    exec(ref_path.read_text(), namespace)
+    return namespace["PRICING"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Discover pay-per-token models")
+    parser.add_argument("--warehouse-id", required=True, help="SQL warehouse ID")
+    args = parser.parse_args()
+
+    w = WorkspaceClient()
+
+    # Query usage table for distinct endpoint/model pairs
+    result = w.statement_execution.execute_statement(
+        warehouse_id=args.warehouse_id,
+        statement="""\
+SELECT DISTINCT endpoint_name, destination_model
+FROM system.ai_gateway.usage
+WHERE event_time >= CURRENT_DATE - INTERVAL 90 DAY
+ORDER BY endpoint_name
+""",
+    )
+
+    discovered = []
+    if result.status.state == "SUCCEEDED" or (
+        hasattr(result.status.state, "value")
+        and result.status.state.value == "SUCCEEDED"
+    ):
+        columns = [col.name for col in result.manifest.schema.columns]
+        for row in result.result.data_array:
+            discovered.append(dict(zip(columns, row)))
+
+    # List all serving endpoints
+    endpoints = []
+    try:
+        for ep in w.serving_endpoints.list():
+            if ep.name and ep.name.startswith("databricks-"):
+                endpoints.append(ep.name)
+    except Exception as e:
+        print(f"Warning: could not list serving endpoints: {e}", file=sys.stderr)
+
+    # Cross-reference with pricing
+    pricing = load_pricing_reference()
+    all_endpoint_names = {d["endpoint_name"] for d in discovered} | set(endpoints)
+    with_pricing = sorted(n for n in all_endpoint_names if n in pricing)
+    missing_pricing = sorted(n for n in all_endpoint_names if n not in pricing)
+
+    output = {
+        "discovered_models": discovered,
+        "available_endpoints": sorted(endpoints),
+        "models_with_pricing": with_pricing,
+        "models_missing_pricing": missing_pricing,
+    }
+
+    json.dump(output, sys.stdout, indent=2)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/update-pricing/scripts/generate_pricing.py
+++ b/.claude/skills/update-pricing/scripts/generate_pricing.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Generate updated pricing.py from pricing reference data.
+
+Reads pricing_reference.py (or accepts JSON on stdin from scrape_pricing)
+and outputs the complete pricing.py module to stdout.
+
+Usage:
+    # From reference file:
+    python generate_pricing.py
+
+    # With discovery JSON to warn about missing models:
+    python generate_pricing.py --discovery discovery.json
+
+    # Update reference file with new scraped data:
+    python generate_pricing.py --update-reference scraped.json
+"""
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PRICING_PY = REPO_ROOT / "usage-limits" / "app" / "core" / "pricing.py"
+REFERENCE_PY = Path(__file__).parent.parent / "references" / "pricing_reference.py"
+
+DBU_RATE_DOLLARS = 0.07
+
+
+def load_pricing_reference() -> dict[str, tuple[float, float]]:
+    """Load pricing from pricing_reference.py."""
+    namespace: dict = {}
+    exec(REFERENCE_PY.read_text(), namespace)
+    return namespace["PRICING"]
+
+
+def generate_pricing_py(pricing: dict[str, tuple[float, float]]) -> str:
+    """Generate the complete pricing.py source code."""
+    values_lines = []
+    for endpoint, (input_rate, output_rate) in sorted(pricing.items()):
+        values_lines.append(
+            f"        ('{endpoint}', {input_rate:.8f}, {output_rate:.8f})"
+        )
+    values_sql = ",\n".join(values_lines)
+
+    return f'''\
+"""Pricing constants and SQL for dollar-based usage cost calculation."""
+
+from __future__ import annotations
+
+DBU_RATE_DOLLARS = {DBU_RATE_DOLLARS}
+
+PRICING_CTE = """\\"\\
+pricing_table AS (
+    SELECT endpoint_name, dbu_per_input_token, dbu_per_output_token FROM (VALUES
+{values_sql}
+    ) AS t(endpoint_name, dbu_per_input_token, dbu_per_output_token)
+)"""
+
+
+def build_usage_cost_query() -> str:
+    """Build SQL that calculates per-user dollar costs over 1d/7d/30d windows.
+
+    Returns one row per requester with:
+      - dollar_cost_1d, dollar_cost_7d, dollar_cost_30d
+      - total_tokens_1d, total_tokens_7d, total_tokens_30d
+      - request_count_1d, request_count_7d, request_count_30d
+    """
+    return f"""\\"\\
+WITH {{PRICING_CTE}},
+model_usage AS (
+    SELECT
+        u.requester,
+        u.endpoint_name,
+        SUM(CASE WHEN u.event_time >= CURRENT_DATE THEN u.input_tokens ELSE 0 END) AS input_tokens_1d,
+        SUM(CASE WHEN u.event_time >= CURRENT_DATE THEN u.output_tokens ELSE 0 END) AS output_tokens_1d,
+        SUM(CASE WHEN u.event_time >= DATE_TRUNC('WEEK', CURRENT_DATE) THEN u.input_tokens ELSE 0 END) AS input_tokens_7d,
+        SUM(CASE WHEN u.event_time >= DATE_TRUNC('WEEK', CURRENT_DATE) THEN u.output_tokens ELSE 0 END) AS output_tokens_7d,
+        SUM(u.input_tokens) AS input_tokens_30d,
+        SUM(u.output_tokens) AS output_tokens_30d,
+        SUM(CASE WHEN u.event_time >= CURRENT_DATE THEN u.total_tokens ELSE 0 END) AS total_tokens_1d,
+        SUM(CASE WHEN u.event_time >= DATE_TRUNC('WEEK', CURRENT_DATE) THEN u.total_tokens ELSE 0 END) AS total_tokens_7d,
+        SUM(u.total_tokens) AS total_tokens_30d,
+        SUM(CASE WHEN u.event_time >= CURRENT_DATE THEN 1 ELSE 0 END) AS request_count_1d,
+        SUM(CASE WHEN u.event_time >= DATE_TRUNC('WEEK', CURRENT_DATE) THEN 1 ELSE 0 END) AS request_count_7d,
+        COUNT(*) AS request_count_30d
+    FROM system.ai_gateway.usage u
+    WHERE u.event_time >= CURRENT_DATE - INTERVAL 30 DAY
+    GROUP BY u.requester, u.endpoint_name
+),
+costed_usage AS (
+    SELECT
+        m.requester,
+        ROUND(COALESCE((m.input_tokens_1d * p.dbu_per_input_token + m.output_tokens_1d * p.dbu_per_output_token) * {{DBU_RATE_DOLLARS}}, 0), 2) AS dollar_cost_1d,
+        ROUND(COALESCE((m.input_tokens_7d * p.dbu_per_input_token + m.output_tokens_7d * p.dbu_per_output_token) * {{DBU_RATE_DOLLARS}}, 0), 2) AS dollar_cost_7d,
+        ROUND(COALESCE((m.input_tokens_30d * p.dbu_per_input_token + m.output_tokens_30d * p.dbu_per_output_token) * {{DBU_RATE_DOLLARS}}, 0), 2) AS dollar_cost_30d,
+        m.total_tokens_1d,
+        m.total_tokens_7d,
+        m.total_tokens_30d,
+        m.request_count_1d,
+        m.request_count_7d,
+        m.request_count_30d
+    FROM model_usage m
+    LEFT JOIN pricing_table p ON m.endpoint_name = p.endpoint_name
+)
+SELECT
+    requester,
+    SUM(dollar_cost_1d) AS dollar_cost_1d,
+    SUM(dollar_cost_7d) AS dollar_cost_7d,
+    SUM(dollar_cost_30d) AS dollar_cost_30d,
+    SUM(total_tokens_1d) AS total_tokens_1d,
+    SUM(total_tokens_7d) AS total_tokens_7d,
+    SUM(total_tokens_30d) AS total_tokens_30d,
+    SUM(request_count_1d) AS request_count_1d,
+    SUM(request_count_7d) AS request_count_7d,
+    SUM(request_count_30d) AS request_count_30d
+FROM costed_usage
+GROUP BY requester
+"""
+'''
+
+
+def update_reference_file(new_data: dict[str, dict]) -> None:
+    """Merge scraped pricing into pricing_reference.py."""
+    existing = load_pricing_reference()
+
+    for endpoint, info in new_data.items():
+        input_rate = info.get("dbu_per_input_token", info.get("input_dbu_per_million", 0) / 1_000_000)
+        output_rate = info.get("dbu_per_output_token", info.get("output_dbu_per_million", 0) / 1_000_000)
+        existing[endpoint] = (input_rate, output_rate)
+
+    lines = [
+        '"""Reference pricing for Databricks pay-per-token models.',
+        "",
+        f"Updated: {date.today().isoformat()}",
+        "Source: https://www.databricks.com/product/pricing/foundation-model-serving",
+        "",
+        "Keys are endpoint_name values from system.ai_gateway.usage.",
+        "Values are (dbu_per_input_token, dbu_per_output_token).",
+        '"""',
+        "",
+        "PRICING: dict[str, tuple[float, float]] = {",
+    ]
+
+    for endpoint in sorted(existing):
+        input_rate, output_rate = existing[endpoint]
+        lines.append(f'    "{endpoint}": ({input_rate:.8f}, {output_rate:.8f}),')
+
+    lines.append("}")
+    lines.append("")
+
+    REFERENCE_PY.write_text("\n".join(lines))
+    print(f"Updated {REFERENCE_PY}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate pricing.py")
+    parser.add_argument(
+        "--discovery", help="Discovery JSON from discover_models.py"
+    )
+    parser.add_argument(
+        "--update-reference", help="Scraped JSON to merge into pricing_reference.py"
+    )
+    args = parser.parse_args()
+
+    if args.update_reference:
+        with open(args.update_reference) as f:
+            new_data = json.load(f)
+        update_reference_file(new_data)
+
+    pricing = load_pricing_reference()
+
+    if args.discovery:
+        with open(args.discovery) as f:
+            discovery = json.load(f)
+        missing = discovery.get("models_missing_pricing", [])
+        if missing:
+            print(
+                f"WARNING: {len(missing)} models have no pricing: {missing}",
+                file=sys.stderr,
+            )
+
+    print(generate_pricing_py(pricing))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/update-pricing/scripts/scrape_pricing.py
+++ b/.claude/skills/update-pricing/scripts/scrape_pricing.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Scrape Databricks Foundation Model Serving pricing via Chrome DevTools MCP.
+
+This script is NOT run directly — it documents the extraction pattern that
+Claude Code executes via Chrome DevTools MCP tool calls.
+
+## Workflow (executed by Claude Code, not as a standalone script):
+
+### Page 1 — Proprietary models (Claude, GPT, Gemini):
+1. Navigate to: https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
+2. Wait for the DBU rates table to render (wait for "DBU" text)
+3. Use the "Select model vendor" combobox to cycle through vendors:
+   - OpenAI (selected by default)
+   - Anthropic
+   - Google
+4. For each vendor, take_snapshot() and extract rows from the
+   "Proprietary Foundation Model Serving DBU rates" table
+5. Use Global endpoint and Short Context rates as the default
+
+### Page 2 — Open-source models (Llama, Gemma, GPT OSS):
+1. Navigate to: https://www.databricks.com/product/pricing/foundation-model-serving
+2. Scroll to "Foundation Model Serving DBU rates" table
+3. take_snapshot() and extract rows
+4. Skip models with "n/a" pay-per-token rates
+
+## DOM Structure (accessibility tree)
+
+The DBU rates table renders as StaticText nodes in the a11y tree.
+For proprietary models, the columns are:
+- Model name, Endpoint type (Global/In-geo), Context Length,
+  Input DBU/1M, Output DBU/1M, Cache writes, Cache reads, Batch DBU/hour
+
+For open-source models, the columns are:
+- Model name, Input DBU/1M, Output DBU/1M, PT entry DBU/hour, PT scaling DBU/hour
+
+### Conversion:
+- Page shows DBU per 1M tokens
+- We need DBU per token: divide by 1,000,000
+- Endpoint name: add "databricks-" prefix, lowercase, spaces to hyphens
+
+## Output format (JSON to stdout):
+
+```json
+{
+  "databricks-claude-sonnet-4": {
+    "input_dbu_per_million": 42.857,
+    "output_dbu_per_million": 214.286,
+    "dbu_per_input_token": 0.000042857,
+    "dbu_per_output_token": 0.000214286
+  },
+  ...
+}
+```
+"""
+
+import json
+import sys
+
+
+def parse_pricing_from_snapshot(snapshot_text: str) -> dict:
+    """Parse pricing data from a Chrome DevTools accessibility snapshot.
+
+    This is a helper for Claude Code to call after taking a snapshot
+    of the pricing page. The snapshot_text is the accessibility tree text.
+
+    Returns dict mapping endpoint_name -> pricing info.
+    """
+    # This function is intentionally a skeleton — Claude Code reads the
+    # actual DOM snapshot and extracts data using its understanding of
+    # the page structure. The function exists to document the expected
+    # output format.
+    raise NotImplementedError(
+        "This function is a template. Use Chrome DevTools MCP to scrape "
+        "the pricing page and parse the snapshot manually."
+    )
+
+
+def normalize_model_name(raw_name: str) -> str:
+    """Convert a raw model name from the pricing page to endpoint_name format.
+
+    Examples:
+        "Claude Sonnet 4" -> "databricks-claude-sonnet-4"
+        "GPT-4o"          -> "databricks-gpt-4o"
+        "Llama 3.3 70B"   -> "databricks-llama-3-3-70b"
+    """
+    name = raw_name.strip().lower()
+    name = name.replace(" ", "-")
+    if not name.startswith("databricks-"):
+        name = f"databricks-{name}"
+    return name
+
+
+def dbu_per_million_to_per_token(dbu_per_million: float) -> float:
+    """Convert DBU/1M tokens to DBU/token."""
+    return dbu_per_million / 1_000_000
+
+
+if __name__ == "__main__":
+    print(
+        "This script documents the scraping pattern for Claude Code.\n"
+        "Run it via the /update-pricing skill, which uses Chrome DevTools MCP.",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/usage-limits/app/core/pricing.py
+++ b/usage-limits/app/core/pricing.py
@@ -6,16 +6,36 @@ DBU_RATE_DOLLARS = 0.07
 
 PRICING_CTE = """\
 pricing_table AS (
-    SELECT model_name, dbu_per_token FROM (VALUES
-        ('claude-3-5-sonnet', 0.0000532),
-        ('claude-3-5-haiku', 0.0000068),
-        ('claude-3-opus', 0.000204),
-        ('claude-3-sonnet', 0.0000408),
-        ('claude-3-haiku', 0.0000034),
-        ('claude-sonnet-4', 0.0000532),
-        ('claude-haiku-4', 0.0000068),
-        ('claude-opus-4', 0.000204)
-    ) AS t(model_name, dbu_per_token)
+    SELECT endpoint_name, dbu_per_input_token, dbu_per_output_token FROM (VALUES
+        ('databricks-claude-opus-4-6', 0.000071429, 0.000357143),
+        ('databricks-claude-opus-4-5', 0.000071429, 0.000357143),
+        ('databricks-claude-opus-4-1', 0.000214286, 0.001071429),
+        ('databricks-claude-opus-4', 0.000214286, 0.001071429),
+        ('databricks-claude-sonnet-4-6', 0.000042857, 0.000214286),
+        ('databricks-claude-sonnet-4-5', 0.000042857, 0.000214286),
+        ('databricks-claude-sonnet-4-1', 0.000042857, 0.000214286),
+        ('databricks-claude-sonnet-4', 0.000042857, 0.000214286),
+        ('databricks-claude-sonnet-3-7', 0.000042857, 0.000214286),
+        ('databricks-claude-haiku-4-5', 0.000014286, 0.000071429),
+        ('databricks-gpt-5-2', 0.000025000, 0.000200000),
+        ('databricks-gpt-5-1', 0.000017857, 0.000142857),
+        ('databricks-gpt-5-1-codex-max', 0.000017857, 0.000142857),
+        ('databricks-gpt-5', 0.000017857, 0.000142857),
+        ('databricks-gpt-5-mini', 0.000003571, 0.000028571),
+        ('databricks-gpt-5-1-codex-mini', 0.000003571, 0.000028571),
+        ('databricks-gpt-5-nano', 0.000000714, 0.000005714),
+        ('databricks-gemini-3-0-pro', 0.000035714, 0.000214286),
+        ('databricks-gemini-3-1-pro', 0.000035714, 0.000214286),
+        ('databricks-gemini-3-0-flash', 0.000008929, 0.000053571),
+        ('databricks-gemini-2-5-pro', 0.000017857, 0.000142857),
+        ('databricks-gemini-2-5-flash', 0.000004286, 0.000035714),
+        ('databricks-llama-4-maverick', 0.000007143, 0.000021429),
+        ('databricks-llama-3-3-70b', 0.000007143, 0.000021429),
+        ('databricks-llama-3-1-8b', 0.000002143, 0.000006429),
+        ('databricks-gpt-oss-120b', 0.000002143, 0.000008571),
+        ('databricks-gpt-oss-20b', 0.000001000, 0.000004286),
+        ('databricks-gemma-3-12b', 0.000002143, 0.000007143)
+    ) AS t(endpoint_name, dbu_per_input_token, dbu_per_output_token)
 )"""
 
 
@@ -29,9 +49,16 @@ def build_usage_cost_query() -> str:
     """
     return f"""\
 WITH {PRICING_CTE},
-usage_agg AS (
+model_usage AS (
     SELECT
         u.requester,
+        u.endpoint_name,
+        SUM(CASE WHEN u.event_time >= CURRENT_DATE THEN u.input_tokens ELSE 0 END) AS input_tokens_1d,
+        SUM(CASE WHEN u.event_time >= CURRENT_DATE THEN u.output_tokens ELSE 0 END) AS output_tokens_1d,
+        SUM(CASE WHEN u.event_time >= DATE_TRUNC('WEEK', CURRENT_DATE) THEN u.input_tokens ELSE 0 END) AS input_tokens_7d,
+        SUM(CASE WHEN u.event_time >= DATE_TRUNC('WEEK', CURRENT_DATE) THEN u.output_tokens ELSE 0 END) AS output_tokens_7d,
+        SUM(u.input_tokens) AS input_tokens_30d,
+        SUM(u.output_tokens) AS output_tokens_30d,
         SUM(CASE WHEN u.event_time >= CURRENT_DATE THEN u.total_tokens ELSE 0 END) AS total_tokens_1d,
         SUM(CASE WHEN u.event_time >= DATE_TRUNC('WEEK', CURRENT_DATE) THEN u.total_tokens ELSE 0 END) AS total_tokens_7d,
         SUM(u.total_tokens) AS total_tokens_30d,
@@ -40,19 +67,34 @@ usage_agg AS (
         COUNT(*) AS request_count_30d
     FROM system.ai_gateway.usage u
     WHERE u.event_time >= CURRENT_DATE - INTERVAL 30 DAY
-    GROUP BY u.requester
+    GROUP BY u.requester, u.endpoint_name
+),
+costed_usage AS (
+    SELECT
+        m.requester,
+        ROUND(COALESCE((m.input_tokens_1d * p.dbu_per_input_token + m.output_tokens_1d * p.dbu_per_output_token) * {DBU_RATE_DOLLARS}, 0), 2) AS dollar_cost_1d,
+        ROUND(COALESCE((m.input_tokens_7d * p.dbu_per_input_token + m.output_tokens_7d * p.dbu_per_output_token) * {DBU_RATE_DOLLARS}, 0), 2) AS dollar_cost_7d,
+        ROUND(COALESCE((m.input_tokens_30d * p.dbu_per_input_token + m.output_tokens_30d * p.dbu_per_output_token) * {DBU_RATE_DOLLARS}, 0), 2) AS dollar_cost_30d,
+        m.total_tokens_1d,
+        m.total_tokens_7d,
+        m.total_tokens_30d,
+        m.request_count_1d,
+        m.request_count_7d,
+        m.request_count_30d
+    FROM model_usage m
+    LEFT JOIN pricing_table p ON m.endpoint_name = p.endpoint_name
 )
 SELECT
-    a.requester,
-    ROUND(COALESCE(a.total_tokens_1d * p.dbu_per_token * {DBU_RATE_DOLLARS}, 0), 2) AS dollar_cost_1d,
-    ROUND(COALESCE(a.total_tokens_7d * p.dbu_per_token * {DBU_RATE_DOLLARS}, 0), 2) AS dollar_cost_7d,
-    ROUND(COALESCE(a.total_tokens_30d * p.dbu_per_token * {DBU_RATE_DOLLARS}, 0), 2) AS dollar_cost_30d,
-    a.total_tokens_1d,
-    a.total_tokens_7d,
-    a.total_tokens_30d,
-    a.request_count_1d,
-    a.request_count_7d,
-    a.request_count_30d
-FROM usage_agg a
-LEFT JOIN pricing_table p ON 1=1
+    requester,
+    SUM(dollar_cost_1d) AS dollar_cost_1d,
+    SUM(dollar_cost_7d) AS dollar_cost_7d,
+    SUM(dollar_cost_30d) AS dollar_cost_30d,
+    SUM(total_tokens_1d) AS total_tokens_1d,
+    SUM(total_tokens_7d) AS total_tokens_7d,
+    SUM(total_tokens_30d) AS total_tokens_30d,
+    SUM(request_count_1d) AS request_count_1d,
+    SUM(request_count_7d) AS request_count_7d,
+    SUM(request_count_30d) AS request_count_30d
+FROM costed_usage
+GROUP BY requester
 """

--- a/usage-limits/app/tests/unit/test_pricing.py
+++ b/usage-limits/app/tests/unit/test_pricing.py
@@ -12,12 +12,31 @@ class TestPricingConstants:
 
         assert DBU_RATE_DOLLARS == 0.07
 
+    def test_pricing_cte_has_input_output_columns(self):
+        from core.pricing import PRICING_CTE
+
+        assert "dbu_per_input_token" in PRICING_CTE
+        assert "dbu_per_output_token" in PRICING_CTE
+
+    def test_pricing_cte_uses_endpoint_name(self):
+        from core.pricing import PRICING_CTE
+
+        assert "endpoint_name" in PRICING_CTE
+        assert "model_name" not in PRICING_CTE
+
     def test_pricing_cte_contains_models(self):
         from core.pricing import PRICING_CTE
 
-        assert "claude-3-5-sonnet" in PRICING_CTE
-        assert "claude-opus-4" in PRICING_CTE
-        assert "claude-sonnet-4" in PRICING_CTE
+        assert "databricks-claude-sonnet-4" in PRICING_CTE
+        assert "databricks-claude-opus-4" in PRICING_CTE
+        assert "databricks-claude-haiku-4-5" in PRICING_CTE
+
+    def test_pricing_cte_contains_non_claude_models(self):
+        from core.pricing import PRICING_CTE
+
+        assert "databricks-gpt-5" in PRICING_CTE
+        assert "databricks-gemini" in PRICING_CTE
+        assert "databricks-llama" in PRICING_CTE
 
 
 @pytest.mark.unit
@@ -35,6 +54,28 @@ class TestBuildUsageCostQuery:
         assert "dollar_cost_7d" in sql
         assert "dollar_cost_30d" in sql
         assert "requester" in sql
+
+    def test_no_cross_join(self):
+        from core.pricing import build_usage_cost_query
+
+        sql = build_usage_cost_query()
+
+        assert "ON 1=1" not in sql
+
+    def test_joins_on_endpoint_name(self):
+        from core.pricing import build_usage_cost_query
+
+        sql = build_usage_cost_query()
+
+        assert "m.endpoint_name = p.endpoint_name" in sql
+
+    def test_uses_separate_input_output_tokens(self):
+        from core.pricing import build_usage_cost_query
+
+        sql = build_usage_cost_query()
+
+        assert "input_tokens" in sql
+        assert "output_tokens" in sql
 
     def test_groups_by_requester(self):
         from core.pricing import build_usage_cost_query

--- a/usage-limits/app/tests/unit/test_usage.py
+++ b/usage-limits/app/tests/unit/test_usage.py
@@ -83,6 +83,18 @@ class TestGetDollarUsage:
         assert "pricing_table" in sql
         assert "system.ai_gateway.usage" in sql
 
+    def test_sql_joins_on_endpoint_name(self, mock_workspace_client, make_query_result):
+        from core.usage import get_dollar_usage
+
+        mock_workspace_client.statement_execution.execute_statement.return_value = (
+            make_query_result(columns=["requester"], rows=[])
+        )
+
+        get_dollar_usage(mock_workspace_client, "wh-id")
+
+        sql = mock_workspace_client.statement_execution.execute_statement.call_args.kwargs["statement"]
+        assert "m.endpoint_name = p.endpoint_name" in sql
+
     def test_empty_result(self, mock_workspace_client, make_query_result):
         from core.usage import get_dollar_usage
 


### PR DESCRIPTION
Replace single dbu_per_token with separate input/output rates, switch from model_name to endpoint_name matching, expand model coverage to include GPT, Gemini, and Llama models, and fix cross-join with proper endpoint_name join. Add update-pricing skill for refreshing rates.