### PR TITLE
feat: add cme CI workflow and deprecate old eval runner (#19)

### DIFF
--- a/.github/workflows/cme-checks.yaml
+++ b/.github/workflows/cme-checks.yaml
@@ -34,11 +34,24 @@ jobs:
       - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
       - name: Check skill overlap
         env:
-            ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_AUTH_TOKEN: ${{ secrets.DATABRICKS_SP_TOKEN }}
-            ANTHROPIC_BASE_URL: ${{ secrets.DATABRICKS_AI_GATEWAY_URL }}
-            ANTHROPIC_MODEL: ${{ secrets.DATABRICKS_AI_GATEWAY_MODEL }}
-            ANTHROPIC_CUSTOM_HEADERS: "x-databricks-use-coding-agent-mode: true"
-            CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
-            CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING: ""
-        run: uvx --from claude-marketplace-evaluator cme overlap --plugins-dir plugins/
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.DATABRICKS_SP_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.DATABRICKS_AI_GATEWAY_URL }}
+          ANTHROPIC_MODEL: ${{ secrets.DATABRICKS_AI_GATEWAY_MODEL }}
+          ANTHROPIC_CUSTOM_HEADERS: "x-databricks-use-coding-agent-mode: true"
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING: ""
+        run: |
+          set +e
+          uvx --from claude-marketplace-evaluator cme overlap --plugins-dir plugins/ --output overlap-report.json
+          EXIT_CODE=$?
+          if [ -f overlap-report.json ]; then
+            echo "## Overlap Report" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat overlap-report.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "--- overlap-report.json ---"
+            cat overlap-report.json
+            echo "---------------------------"
+          fi
+          exit $EXIT_CODE

--- a/.github/workflows/cme-checks.yaml
+++ b/.github/workflows/cme-checks.yaml
@@ -28,6 +28,7 @@ jobs:
 
   overlap:
     runs-on: ubuntu-latest
+    environment: cicd
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4

--- a/.github/workflows/cme-checks.yaml
+++ b/.github/workflows/cme-checks.yaml
@@ -10,11 +10,21 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    environment: cicd
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
-      - name: Check eval coverage
-        run: uvx --from claude-marketplace-evaluator cme routing --plugins-dir plugins/ --coverage-threshold 100
+      - name: Check eval coverage and routing
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.DATABRICKS_SP_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.DATABRICKS_AI_GATEWAY_URL }}
+          ANTHROPIC_MODEL: ${{ secrets.DATABRICKS_AI_GATEWAY_MODEL }}
+          ANTHROPIC_CUSTOM_HEADERS: "x-databricks-use-coding-agent-mode: true"
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING: ""
+        run: uvx --from claude-marketplace-evaluator cme routing --plugins-dir plugins/ --coverage-threshold 100 --threshold 95
 
   overlap:
     runs-on: ubuntu-latest

--- a/.github/workflows/cme-checks.yaml
+++ b/.github/workflows/cme-checks.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
       - name: Check eval coverage
-        run: uvx claude-marketplace-evaluator routing --plugins-dir plugins/ --coverage-threshold 100
+        run: uvx --from claude-marketplace-evaluator cme routing --plugins-dir plugins/ --coverage-threshold 100
 
   overlap:
     runs-on: ubuntu-latest
@@ -22,4 +22,4 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
       - name: Check skill overlap
-        run: uvx claude-marketplace-evaluator overlap --plugins-dir plugins/
+        run: uvx --from claude-marketplace-evaluator cme overlap --plugins-dir plugins/

--- a/.github/workflows/cme-checks.yaml
+++ b/.github/workflows/cme-checks.yaml
@@ -33,4 +33,12 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
       - name: Check skill overlap
+        env:
+            ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            ANTHROPIC_AUTH_TOKEN: ${{ secrets.DATABRICKS_SP_TOKEN }}
+            ANTHROPIC_BASE_URL: ${{ secrets.DATABRICKS_AI_GATEWAY_URL }}
+            ANTHROPIC_MODEL: ${{ secrets.DATABRICKS_AI_GATEWAY_MODEL }}
+            ANTHROPIC_CUSTOM_HEADERS: "x-databricks-use-coding-agent-mode: true"
+            CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+            CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING: ""
         run: uvx --from claude-marketplace-evaluator cme overlap --plugins-dir plugins/

--- a/.github/workflows/cme-checks.yaml
+++ b/.github/workflows/cme-checks.yaml
@@ -24,7 +24,7 @@ jobs:
           ANTHROPIC_CUSTOM_HEADERS: "x-databricks-use-coding-agent-mode: true"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING: ""
-        run: uvx --from claude-marketplace-evaluator cme routing --plugins-dir plugins/ --coverage-threshold 100 --threshold 95
+        run: uvx --from claude-marketplace-evaluator cme routing --plugins-dir plugins/ --coverage-threshold 100 --threshold 95 --timeout 180
 
   overlap:
     runs-on: ubuntu-latest

--- a/.github/workflows/cme-checks.yaml
+++ b/.github/workflows/cme-checks.yaml
@@ -1,0 +1,25 @@
+name: CME Checks
+
+on:
+  pull_request:
+    paths:
+      - "plugins/**"
+      - "evals/**"
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
+      - name: Check eval coverage
+        run: uvx claude-marketplace-evaluator routing --plugins-dir plugins/ --coverage-threshold 100
+
+  overlap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
+      - name: Check skill overlap
+        run: uvx claude-marketplace-evaluator overlap --plugins-dir plugins/

--- a/.github/workflows/skill-routing-evals.yaml
+++ b/.github/workflows/skill-routing-evals.yaml
@@ -1,10 +1,6 @@
 name: Skill Routing Evals
 
 on:
-  pull_request:
-    paths:
-      - "plugins/**/SKILL.md"
-      - "evals/**"
   workflow_dispatch:
     inputs:
       base_url:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ evals/.venv/
 .claude/skills/staging/
 .mcp.json
 .coverage
+.omc/

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ FILTER    ?=           ## Eval name filter substring (default: none)
 PLUGIN    ?=           ## Plugin name for scoped evals, e.g. PLUGIN=databricks-skills (default: all)
 WORKERS   ?= 8         ## Parallel eval workers (default: 8)
 TIMEOUT   ?= 180       ## Per-test timeout in seconds (default: 180)
-THRESHOLD ?= 95        ## Minimum pass percentage (default: 95)
+THRESHOLD ?= 95        ## Minimum pass percentage (default: 95; also used by cme-routing)
 RETRIES   ?= 5         ## Max retries on rate limit (default: 5)
 
 # Auto-source inference config if it exists
@@ -49,6 +49,18 @@ help:
 	@echo "Variables (override with VAR=value):"
 	@awk '/^[A-Z_]+ +\?=/{split($$0,a,"## "); gsub(/\?=.*/, "", $$1); printf "  %-20s %s\n", $$1, a[2]}' $(MAKEFILE_LIST)
 
+## Check eval coverage via cme (fast, no API keys)
+cme-coverage:
+	uvx claude-marketplace-evaluator routing --plugins-dir plugins/ --coverage-threshold 100
+
+## Check skill overlap via cme (fast, no API keys)
+cme-overlap:
+	uvx claude-marketplace-evaluator overlap --plugins-dir plugins/
+
+## Run full cme routing evals with configurable pass-rate threshold
+cme-routing:
+	uvx claude-marketplace-evaluator routing --plugins-dir plugins/ --coverage-threshold 100 --threshold $(THRESHOLD)
+
 ## Validate skill structure and frontmatter
 validate:
 ifeq ($(SKILL),)
@@ -57,6 +69,7 @@ else
 	bash scripts/validate-skill.sh $(SKILL)
 endif
 
+## DEPRECATED: use cme-* targets instead
 ## Run skill routing evals (uses all.yaml by default; set PLUGIN=<name> to scope to one plugin)
 ## NOTE: Run 'make evals-generate' first if you have modified any evals/evals.json files.
 evals:
@@ -80,12 +93,14 @@ else
 		$(if $(FILTER),--filter $(FILTER))
 endif
 
+## DEPRECATED: use cme-* targets instead
 ## Generate routing test YAMLs from per-skill evals/evals.json files
 evals-generate:
 	python3 evals/scripts/generate-routing-tests.py \
 		--plugins-dir plugins/ \
 		--out-dir evals/test-cases/
 
+## DEPRECATED: use cme-* targets instead
 ## Check that generated routing test YAMLs are up-to-date (used in CI)
 evals-check-generated:
 	@tmpdir=$$(mktemp -d) && \
@@ -100,6 +115,7 @@ evals-check-generated:
 		echo "OK: Generated routing YAMLs are up-to-date."; \
 	fi
 
+## DEPRECATED: use cme-* targets instead
 ## Install eval Python dependencies
 evals-install:
 	cd evals && uv sync
@@ -164,7 +180,8 @@ test-app-unit:
 test-app-integration:
 	cd $(APP)/app && uv run pytest tests/ -m integration -v
 
-.PHONY: help validate evals evals-generate evals-check-generated evals-install \
+.PHONY: help validate cme-coverage cme-overlap cme-routing \
+	evals evals-generate evals-check-generated evals-install \
 	install-local uninstall-local init configure configure-otel \
 	unconfigure unconfigure-otel \
 	app-install test-app test-app-coverage test-app-unit test-app-integration

--- a/Makefile
+++ b/Makefile
@@ -51,15 +51,15 @@ help:
 
 ## Check eval coverage via cme (fast, no API keys)
 cme-coverage:
-	uvx claude-marketplace-evaluator routing --plugins-dir plugins/ --coverage-threshold 100
+	uvx --from claude-marketplace-evaluator cme routing --plugins-dir plugins/ --coverage-threshold 100
 
 ## Check skill overlap via cme (fast, no API keys)
 cme-overlap:
-	uvx claude-marketplace-evaluator overlap --plugins-dir plugins/
+	uvx --from claude-marketplace-evaluator cme overlap --plugins-dir plugins/
 
 ## Run full cme routing evals with configurable pass-rate threshold
 cme-routing:
-	uvx claude-marketplace-evaluator routing --plugins-dir plugins/ --coverage-threshold 100 --threshold $(THRESHOLD)
+	uvx --from claude-marketplace-evaluator cme routing --plugins-dir plugins/ --coverage-threshold 100 --threshold $(THRESHOLD)
 
 ## Validate skill structure and frontmatter
 validate:

--- a/evals/src/skill_evals/__init__.py
+++ b/evals/src/skill_evals/__init__.py
@@ -1,3 +1,7 @@
+# DEPRECATED: This package is deprecated in favor of claude-marketplace-evaluator (cme).
+# Use `uvx claude-marketplace-evaluator` for coverage checks and overlap detection.
+# This code is preserved for reference and will be removed in a future cleanup (see issue #23).
+
 from .models import TestCase, TestResult
 
 __all__ = ["TestCase", "TestResult"]


### PR DESCRIPTION
## Summary
• Adds new `.github/workflows/cme-checks.yaml` with coverage and overlap jobs using pinned action SHAs
• Disables auto-trigger on old `skill-routing-evals.yaml` (keeps workflow_dispatch for manual runs)
• Adds `cme-coverage`, `cme-overlap`, `cme-routing` Makefile targets and deprecates old eval targets
• Adds deprecation notice to `evals/src/skill_evals/__init__.py` pointing to claude-marketplace-evaluator

## Test plan
• Verify cme-checks.yaml triggers on PRs touching plugins/ or evals/
• Verify old skill-routing-evals.yaml no longer auto-triggers on PRs
• Run `make cme-coverage` and `make cme-overlap` locally to confirm they invoke cme correctly
• Confirm `make help` shows new targets and deprecation comments

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)