### PR TITLE
test: trigger PR-aware overlap CI check (do not merge)

### DIFF
--- a/plugins/dev-workflow/skills/test-overlap-trigger/SKILL.md
+++ b/plugins/dev-workflow/skills/test-overlap-trigger/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: test-overlap-trigger
+description: Temporary test skill to trigger PR-aware overlap CI check. Do not merge.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Test Overlap Trigger
+
+This is a temporary skill used to trigger the PR-aware `cme overlap` CI check.
+
+**Do not merge this PR.**


### PR DESCRIPTION
Temporary PR to test the new PR-aware `cme overlap` workflow. Adds a dummy skill to `dev-workflow` to trigger the overlap job.

**Do not merge — close after verifying CI.**