### PR TITLE
feat: add destructive-guard plugin v0.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,6 +78,16 @@
         "name": "AI engineering"
       },
       "category": "enterprise"
+    },
+    {
+      "name": "icerhymers-destructive-guard",
+      "source": "./plugins/destructive-guard",
+      "description": "PreToolUse hook blocking destructive Bash commands with a tunable ruleset",
+      "version": "0.1.0",
+      "author": {
+        "name": "AI engineering"
+      },
+      "category": "safety"
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ PLUGINS := \
 	icerhymers-specialized-tools \
 	icerhymers-databricks-mcp \
 	icerhymers-databricks-otel \
-	icerhymers-budget-checker
+	icerhymers-budget-checker \
+	icerhymers-destructive-guard
 
 MARKETPLACE := icerhymers-marketplace
 

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,1 @@
+{"plugins":["destructive-guard"]}

--- a/plugins/destructive-guard/.claude-plugin/plugin.json
+++ b/plugins/destructive-guard/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "icerhymers-destructive-guard",
+  "description": "Pre-execution guardrail for Bash. Blocks unambiguous catastrophes (rm -rf /, force-push to main, terraform destroy, curl|sh, DROP DATABASE, secret exfil) using a tunable bash-only ruleset. Zero network. Fails open.",
+  "version": "0.1.0",
+  "author": {
+    "name": "AI engineering"
+  },
+  "skills": "./skills/",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/guard.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/destructive-guard/scripts/guard.sh
+++ b/plugins/destructive-guard/scripts/guard.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# destructive-guard hook script.
+#
+# PreToolUse hook on the Bash tool. Reads the hook payload from stdin, applies
+# HARD_DENY then SOFT_DENY rules from rules.conf, and either:
+#   - emits empty stdout + exits 0 (allow), or
+#   - emits a permissionDecision=deny JSON object (block + reason to model).
+#
+# Contract:
+#   stdin : Claude Code hook payload JSON.
+#   stdout: empty (allow) or hook-decision JSON (block).
+#   exit  : always 0. We FAIL OPEN on any internal error — a broken guardrail
+#           must never break the agent.
+
+set -u  # NB: NOT -e. We explicitly handle errors and never want to abort non-zero.
+
+# Always exit 0, even if a subshell trips ERR.
+allow() { exit 0; }
+trap 'exit 0' ERR
+
+# --- Hard prerequisite: jq. If missing, allow. ---
+command -v jq >/dev/null 2>&1 || allow
+
+CONF="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}/scripts/rules.conf"
+[[ -r "$CONF" ]] || allow
+
+LOG_FILE="${HOME}/.claude/destructive-guard.log"
+
+# --- Read hook payload ---
+PAYLOAD="$(cat 2>/dev/null || true)"
+[[ -z "$PAYLOAD" ]] && allow
+
+CMD="$(printf '%s' "$PAYLOAD" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[[ -z "$CMD" ]] && allow
+
+SESSION_ID="$(printf '%s' "$PAYLOAD" | jq -r '.session_id // "unknown"' 2>/dev/null || echo unknown)"
+CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty' 2>/dev/null || true)"
+CWD="${CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+
+# --- Load SETTINGS from rules.conf ---
+get_setting() {
+  awk -F= -v k="$1" '
+    /^## SECTION:/ { in_sec = ($0 ~ "## SECTION: SETTINGS"); next }
+    in_sec && $1 == k { sub(/^[^=]*=/, ""); print; exit }
+  ' "$CONF"
+}
+
+OVERRIDE_PATTERN="$(get_setting OVERRIDE_TOKEN_PATTERN)"
+[[ -z "$OVERRIDE_PATTERN" ]] && OVERRIDE_PATTERN='DG-OK-[a-f0-9]{6}'
+PROTECTED_BRANCHES="$(get_setting PROTECTED_BRANCHES)"
+PROTECTED_BRANCHES="${PROTECTED_BRANCHES:-main,master,prod,production}"
+PROTECTED_NAMESPACES="$(get_setting PROTECTED_NAMESPACES)"
+PROTECTED_NAMESPACES="${PROTECTED_NAMESPACES:-prod,production,kube-system}"
+SAFE_PATH_PREFIXES="$(get_setting SAFE_PATH_PREFIXES)"
+
+# Branch / namespace lists -> regex alternations for token interpolation.
+BR_ALT="$(printf '%s' "$PROTECTED_BRANCHES" | tr ',' '|')"
+NS_ALT="$(printf '%s' "$PROTECTED_NAMESPACES" | tr ',' '|')"
+
+# --- Logger ---
+log_line() {
+  # severity, category, reason
+  local severity="$1" category="$2" reason="$3"
+  mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || return 0
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+  local snippet="${CMD:0:200}"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$ts" "$SESSION_ID" "$severity" "$category" "$reason" "$snippet" \
+    >>"$LOG_FILE" 2>/dev/null || true
+}
+
+# --- Override token check ---
+# Presence-only: a string of OVERRIDE_PATTERN shape anywhere in the command
+# downgrades any deny to allow + OVERRIDE log.
+HAS_OVERRIDE=0
+if printf '%s' "$CMD" | grep -Eq "$OVERRIDE_PATTERN" 2>/dev/null; then
+  HAS_OVERRIDE=1
+fi
+
+if [[ $HAS_OVERRIDE -eq 1 ]]; then
+  log_line "OVERRIDE" "override" "override token present; all checks bypassed"
+  allow
+fi
+
+# --- Section extractor ---
+section() {
+  awk -v sec="$1" '
+    /^## SECTION:/ { in_sec = ($0 ~ "## SECTION: " sec); next }
+    in_sec && /^[^#[:space:]]/ && NF { print }
+  ' "$CONF"
+}
+
+# --- Path-escape check (for cwd-scoped rules) ---
+# Returns 0 (true) if the first path-shaped arg in the command escapes $CWD
+# AND is not under any SAFE_PATH_PREFIXES entry.
+path_escapes_cwd() {
+  local cmd="$1" p resolved
+  p="$(printf '%s' "$cmd" | grep -oE '(/[A-Za-z0-9._/~$-]+|~/[A-Za-z0-9._/~$-]*|\$HOME/[A-Za-z0-9._/-]*|\.\./[A-Za-z0-9._/-]*)' 2>/dev/null | head -1)"
+  [[ -z "$p" ]] && return 1   # no absolute path -> not escaping
+  p="${p//\$HOME/$HOME}"
+  p="${p/#\~/$HOME}"
+  resolved="$(cd "$CWD" 2>/dev/null && cd "$(dirname "$p")" 2>/dev/null && printf '%s/%s' "$(pwd)" "$(basename "$p")")"
+  resolved="${resolved:-$p}"
+  [[ "$resolved" == "$CWD"* ]] && return 1
+  local IFS=','
+  for pre in $SAFE_PATH_PREFIXES; do
+    pre="${pre//\$HOME/$HOME}"
+    pre="${pre//\$TMPDIR/${TMPDIR:-/tmp}}"
+    [[ -z "$pre" ]] && continue
+    [[ "$resolved" == "$pre"* ]] && return 1
+  done
+  return 0
+}
+
+# --- Decision emitter (deny) ---
+emit_deny() {
+  local severity="$1" category="$2" reason="$3" suggestion="$4"
+  local msg="[GUARDRAIL/${severity}] Blocked: ${reason}."
+  [[ -n "$suggestion" ]] && msg="${msg} ${suggestion}"
+  msg="${msg} If intentional, re-issue the command with an override token of the form ${OVERRIDE_PATTERN} appended (e.g. in a comment)."
+  log_line "$severity" "$category" "$reason"
+  jq -n \
+    --arg reason "$msg" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}' \
+    2>/dev/null || printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$reason"
+  exit 0
+}
+
+# --- Rule line parser ---
+# A rule line is "<regex>|<reason>|<category>". The regex may itself contain |
+# characters (alternation). We split from the RIGHT: category is the last
+# field, reason is the second-to-last, and pattern is everything before that.
+parse_rule() {
+  local line="$1"
+  RULE_CATEGORY="${line##*|}"
+  local rest="${line%|*}"
+  RULE_REASON="${rest##*|}"
+  RULE_PATTERN="${rest%|*}"
+}
+
+# --- Process HARD_DENY rules ---
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  parse_rule "$line"
+  [[ -z "$RULE_PATTERN" ]] && continue
+  # Special-case: git-force category — short-circuit if --force-with-lease present.
+  if [[ "$RULE_CATEGORY" == "git-force" ]]; then
+    if printf '%s' "$CMD" | grep -qE -- '--force-with-lease' 2>/dev/null; then
+      continue
+    fi
+  fi
+  # Token interpolation.
+  pat="${RULE_PATTERN//__PROTECTED_BRANCHES__/$BR_ALT}"
+  pat="${pat//__PROTECTED_NAMESPACES__/$NS_ALT}"
+  if printf '%s' "$CMD" | grep -Eq "$pat" 2>/dev/null; then
+    emit_deny "HARD" "$RULE_CATEGORY" "$RULE_REASON" ""
+  fi
+done < <(section HARD_DENY)
+
+# --- Process SOFT_DENY rules ---
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  parse_rule "$line"
+  [[ -z "$RULE_PATTERN" ]] && continue
+  pat="${RULE_PATTERN//__PROTECTED_BRANCHES__/$BR_ALT}"
+  pat="${pat//__PROTECTED_NAMESPACES__/$NS_ALT}"
+  if printf '%s' "$CMD" | grep -Eq "$pat" 2>/dev/null; then
+    if [[ "$RULE_CATEGORY" == "cwd-scoped" ]]; then
+      path_escapes_cwd "$CMD" || continue
+    fi
+    suggestion=""
+    case "$RULE_CATEGORY" in
+      git)         suggestion="Safer alternative: use a non-destructive form (e.g. git stash) or scope to a specific path." ;;
+      db)          suggestion="Safer alternative: run against a test DSN, wrap in a transaction, or add an explicit WHERE clause." ;;
+      cwd-scoped)  suggestion="Safer alternative: scope the path to inside the project directory, or list specific files instead of -r." ;;
+      disk)        suggestion="Safer alternative: narrow the scope to specific files." ;;
+      system)      suggestion="Safer alternative: target a specific PID or process name without -9." ;;
+      *)           suggestion="" ;;
+    esac
+    emit_deny "SOFT" "$RULE_CATEGORY" "$RULE_REASON" "$suggestion"
+  fi
+done < <(section SOFT_DENY)
+
+# --- Allow ---
+allow

--- a/plugins/destructive-guard/scripts/rules.conf
+++ b/plugins/destructive-guard/scripts/rules.conf
@@ -1,0 +1,84 @@
+# ============================================================
+# destructive-guard rules.conf
+# ============================================================
+# Format: regex|reason|category
+#   - regex: ERE (grep -E) syntax
+#   - reason: short human-readable explanation (shown to the model)
+#   - category: one of disk|git|db|cloud|creds|system|evasion|cwd-scoped|git-force
+#
+# Comment a line out to disable a rule.
+# Operators: edit this file. Do NOT edit guard.sh.
+# ============================================================
+
+## SECTION: SETTINGS
+# Override token format: <PREFIX>-<6 hex chars>. Presence of a token of this
+# shape in the command downgrades a HARD/SOFT deny to an OVERRIDE log + allow.
+OVERRIDE_TOKEN_PATTERN=DG-OK-[a-f0-9]{6}
+# Comma-separated list of git branches that are protected against force-push.
+PROTECTED_BRANCHES=main,master,prod,production
+# Comma-separated list of k8s namespaces that are protected against deletion.
+PROTECTED_NAMESPACES=prod,production,kube-system
+# Path prefixes that are always considered "safe destinations" for rm-style
+# CWD-scoped rules. Comma-separated.
+SAFE_PATH_PREFIXES=/tmp/,/var/tmp/
+
+## SECTION: HARD_DENY
+# ---- DISK / DEVICE / FILESYSTEM ----
+# Recursive forced delete of root, ~, $HOME, or /* (with no-preserve-root flag).
+\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(/(\s|$)|~(\s|$)|\$HOME(\s|$)|/\*|--no-preserve-root)|rm -rf on root, home, or no-preserve-root|disk
+# Recursive forced delete of system paths.
+\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+/(etc|usr|var|boot|sys|proc|bin|sbin|lib|lib64|opt|root)(/|\s|$)|rm -rf on a system path|disk
+# Recursive forced delete inside the user's home directory tree.
+\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(~|\$HOME)/[A-Za-z]|rm -rf on a user-data subtree|disk
+# Raw block-device writes.
+\b(dd|mkfs(\.[a-z0-9]+)?|wipefs|shred)\b[^\n]*\s/dev/(sd|nvme|hd|xvd|mmcblk)|raw write to a block device|disk
+>\s*/dev/(sd|nvme|hd|xvd|mmcblk)|redirection to a block device|disk
+
+# ---- GIT FORCE-PUSH (category=git-force triggers --force-with-lease bypass) ----
+# Force-push to a protected branch. The git-force category tells guard.sh to
+# short-circuit if --force-with-lease is present in the command.
+\bgit\s+push\s+(--force|-[a-zA-Z]*f[a-zA-Z]*)\s+.*(__PROTECTED_BRANCHES__)(\s|$)|force-push to a protected branch|git-force
+\bgit\s+push\s+.*--force\s.*(__PROTECTED_BRANCHES__)(\s|$)|force-push (flag-after-args) to a protected branch|git-force
+\bgit\s+push\s+.*\s\+(__PROTECTED_BRANCHES__)(\s|$)|refspec-form force-push to a protected branch|git-force
+
+# ---- DESTRUCTIVE SQL DDL ----
+\bDROP\s+DATABASE\b|DROP DATABASE statement|db
+\bDROP\s+TABLE\b|DROP TABLE statement|db
+\bTRUNCATE(\s+TABLE)?\b|TRUNCATE TABLE statement|db
+
+# ---- CLOUD / KUBERNETES MASS DELETE ----
+\bkubectl\s+delete\s+(ns|namespace)\s+(__PROTECTED_NAMESPACES__)\b|delete a protected k8s namespace|cloud
+\baws\s+s3(api)?\s+(rm\s+[^\n]*--recursive|delete-bucket)\s+s3://|S3 bucket/object mass delete|cloud
+\baws\s+[^\n]*--recursive[^\n]*\ss3://|aws --recursive against s3://|cloud
+
+# ---- CREDENTIAL EXFIL ----
+\bcat\s+[^\n]*id_rsa\b|read SSH private key (id_rsa)|creds
+\bcat\s+[^\n]*\.ssh/(id_|.*_rsa|.*_ed25519|.*_ecdsa)|read SSH private key|creds
+\bcat\s+[^\n]*\.aws/credentials\b|read AWS credentials file|creds
+\becho\s+[^\n]*AWS_SECRET|echo of AWS_SECRET (likely exfil)|creds
+
+# ---- ENCODED EVASION / RCE SHAPES ----
+(curl|wget|fetch)\s+[^\n|;]*\|\s*(sudo\s+)?(bash|sh|zsh|dash)\b|curl/wget piped into shell|evasion
+
+# ---- PERMISSION WIDENING (setuid) ----
+\bchmod\s+[^\n]*\+s\b|chmod +s (setuid bit)|system
+\bchmod\s+[0-7]*[2367][0-7][0-7][0-7]\b|chmod with setuid octal bit|system
+
+## SECTION: SOFT_DENY
+# Soft denies still block, but with a friendlier message that suggests how to
+# proceed safely. They're the "almost-always-wrong" patterns that have
+# legitimate-but-rare use cases.
+
+# Recursive force-delete (CWD-scoped: blocked when path escapes project dir).
+\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\b|recursive force-delete (rm -rf)|cwd-scoped
+# Untracked-file destruction.
+\bgit\s+clean\s+-[a-zA-Z]*f[a-zA-Z]*d|git clean -fd (deletes untracked files)|git
+# Unconditional process kills.
+\bpkill\s+-9\b|pkill -9 (uncatchable kill)|system
+\bkill\s+-9\s+1(\s|$)|kill PID 1 (init)|system
+
+## SECTION: CWD_SCOPED
+# Marker section. Rules in HARD/SOFT marked category=cwd-scoped only fire when
+# the resolved path argument escapes $CLAUDE_PROJECT_DIR (or its fallback, the
+# script's CWD) AND is not under any SAFE_PATH_PREFIXES entry. The check is
+# performed by guard.sh against the FIRST path-shaped argument in the command.

--- a/plugins/destructive-guard/skills/guard-setup/SKILL.md
+++ b/plugins/destructive-guard/skills/guard-setup/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: guard-setup
+description: >
+  Explains the destructive-guard plugin: what commands it blocks, how to tune
+  rules.conf (add/remove rules, change protected branches, use the override token),
+  how to check the audit log, and how to diagnose false positives.
+  Use when an operator asks how to configure the destructive command guard, why
+  a command was blocked, or how to allow a specific command the guard is blocking.
+user-invocable: true
+---
+
+# destructive-guard configuration
+
+The `destructive-guard` plugin is a `PreToolUse` hook that blocks unambiguously dangerous Bash commands before the model can execute them. It is pure bash + `jq`, has no network calls, and **fails open**: a malformed `rules.conf`, a missing `jq` binary, or any internal error allows the command through. A guardrail that breaks the agent is a guardrail that gets uninstalled within a day.
+
+## What it blocks (out of the box)
+
+Two severities:
+
+- **HARD_DENY** — patterns that are essentially never legitimate from an autonomous coding agent. Examples: `rm -rf /`, `rm -rf ~/projects/...`, force-push to a protected branch (`main`/`master`/`prod`/`production`), `DROP TABLE`, `TRUNCATE TABLE`, `kubectl delete namespace prod`, `aws s3 ... --recursive s3://`, `curl ... | bash`, `cat ~/.ssh/id_rsa`, `chmod +s`, raw writes to `/dev/sd*`/`/dev/nvme*`.
+- **SOFT_DENY** — patterns that are usually destructive but have legitimate edge cases. Examples: `rm -rf` (CWD-scoped — only blocks when the path escapes the project directory), `git clean -fd`, `pkill -9`, `kill -9 1`. These deny with a "here's the safer alternative" suggestion.
+
+`git push --force` is in HARD_DENY, but `git push --force-with-lease` short-circuits the rule and is always allowed — the guard recognises the safe form.
+
+## File layout
+
+```
+plugins/destructive-guard/
+  scripts/
+    guard.sh       # Hook script. Do NOT edit unless changing CORE behaviour.
+    rules.conf     # Tunable ruleset. THIS is what you edit.
+```
+
+## `rules.conf` format
+
+Sectioned plain text. Sections are introduced by `## SECTION: NAME` markers.
+
+- `## SECTION: SETTINGS` — `KEY=value` pairs.
+  - `OVERRIDE_TOKEN_PATTERN=DG-OK-[a-f0-9]{6}` — regex for the per-command override token.
+  - `PROTECTED_BRANCHES=main,master,prod,production` — interpolated as a regex alternation into rules that contain the `__PROTECTED_BRANCHES__` token.
+  - `PROTECTED_NAMESPACES=prod,production,kube-system` — same, for `__PROTECTED_NAMESPACES__`.
+  - `SAFE_PATH_PREFIXES=/tmp/,/var/tmp/` — paths under these are always allowed for CWD-scoped rules.
+- `## SECTION: HARD_DENY` and `## SECTION: SOFT_DENY` — one rule per line:
+
+  ```
+  <extended-regex>|<short reason>|<category>
+  ```
+
+  Categories: `disk`, `git`, `git-force`, `db`, `cloud`, `creds`, `system`, `evasion`, `cwd-scoped`. The `git-force` category is special — guard.sh skips the rule when `--force-with-lease` is in the command. The `cwd-scoped` category (used in SOFT_DENY) only fires when the command's first path argument escapes the project directory.
+- `## SECTION: CWD_SCOPED` — marker section, no rules of its own; documents the cwd-scoping behaviour.
+
+Lines starting with `#` are comments. Blank lines are ignored.
+
+## Common operator tasks
+
+### Disable a rule
+
+Comment it out by prefixing with `#`. Example — allow `pkill -9`:
+
+```diff
+- \bpkill\s+-9\b|pkill -9 (uncatchable kill)|system
++ # \bpkill\s+-9\b|pkill -9 (uncatchable kill)|system
+```
+
+`guard.sh` re-reads `rules.conf` on every invocation, so the change takes effect immediately. No restart.
+
+### Add a new rule
+
+Append to the appropriate `## SECTION:` block. Example — block `vault delete` against a prod path:
+
+```
+\bvault\s+delete\s+secret/prod/|vault secret delete in prod|cloud
+```
+
+Keep regexes ERE-compatible (`grep -E`). Avoid PCRE features (no `(?!...)`, no `\d`).
+
+### Change protected branches or namespaces
+
+Edit `## SECTION: SETTINGS`:
+
+```
+PROTECTED_BRANCHES=main,master,prod,production,release,trunk
+PROTECTED_NAMESPACES=prod,production,kube-system,live
+```
+
+Both lists are interpolated wherever `__PROTECTED_BRANCHES__` / `__PROTECTED_NAMESPACES__` appears in a rule pattern.
+
+### Override token (one-shot bypass)
+
+Every deny message includes a token of the form `DG-OK-<6 hex chars>`. Re-issuing the same command with the token appended (typically in a shell comment) bypasses **all** guard checks for that single invocation:
+
+```
+psql -c "DROP TABLE users;"                          # blocked, token DG-OK-a1b2c3 returned
+psql -c "DROP TABLE users; -- DG-OK-a1b2c3"          # allowed, logged as OVERRIDE
+```
+
+The check is presence-only — any string matching `OVERRIDE_TOKEN_PATTERN` anywhere in the command unlocks it. The token is a UX gate, not a cryptographic one; the point is to force an explicit "yes, I meant it" loop on the model. Operators wanting stricter overrides can change the prefix per deployment:
+
+```
+OVERRIDE_TOKEN_PATTERN=ACME-PROD-OK-[a-f0-9]{6}
+```
+
+## Audit log
+
+All blocks and overrides append to `~/.claude/destructive-guard.log`, tab-separated:
+
+```
+<iso-timestamp>\t<session_id>\t<HARD|SOFT|OVERRIDE>\t<category>\t<reason>\t<command snippet>
+```
+
+Tail it to see what the agent has been blocked from doing recently:
+
+```
+tail -f ~/.claude/destructive-guard.log
+```
+
+## Diagnosing false positives
+
+1. **Find the matching rule.** The deny message names the reason. Grep `rules.conf` for it. The matching regex is what blocked the command.
+2. **Pick a fix:**
+   - **One-time pass** — re-issue with the override token from the deny message.
+   - **Permanent pass for this project** — comment the rule out, or narrow the pattern (add a path scope, exclude a known-safe form).
+   - **Permanent pass org-wide** — patch the rule and submit a PR upstream.
+3. **Verify.** `guard.sh` re-reads `rules.conf` on each invocation — no restart. Run any benign command to confirm the agent is unblocked.
+
+## When NOT to add a rule
+
+The guard catches **unambiguous catastrophes**, not style or hygiene issues. Push back on rules that would have a >5% false-positive rate against real dev workflows — a guardrail that fires on legitimate work gets disabled within a day, and then it can't catch the real catastrophe. Style enforcement belongs in repo-level pre-commit hooks; supply-chain checks belong in lockfile-aware tools (Socket, Snyk); long-command heuristics belong nowhere.

--- a/plugins/destructive-guard/skills/guard-setup/evals/evals.json
+++ b/plugins/destructive-guard/skills/guard-setup/evals/evals.json
@@ -1,0 +1,9 @@
+[
+  {"query": "why did the guard block my rm command?", "should_trigger": true},
+  {"query": "how do I add a new rule to the destructive guard?", "should_trigger": true},
+  {"query": "the guard is blocking a command I need, how do I bypass it?", "should_trigger": true},
+  {"query": "how do I check what commands have been blocked?", "should_trigger": true},
+  {"query": "how do I change the protected branches in the guard?", "should_trigger": true},
+  {"query": "set up a new Databricks workspace", "should_trigger": false},
+  {"query": "run my test suite", "should_trigger": false}
+]

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -106,6 +106,7 @@ FILES_TO_REPLACE=(
   "plugins/databricks-mcp/skills/mcp-setup/SKILL.md"
   "plugins/databricks-otel/.claude-plugin/plugin.json"
   "plugins/budget-checker/.claude-plugin/plugin.json"
+  "plugins/destructive-guard/.claude-plugin/plugin.json"
   "scripts/install.sh"
   "scripts/update.sh"
   "docs/INSTALL.md"


### PR DESCRIPTION
Closes #30.

## Summary

Adds the `destructive-guard` plugin: a `PreToolUse` hook on `Bash` that blocks unambiguously destructive shell commands using a tunable `rules.conf`. Pure bash + `jq`, zero network, fails open on any internal error.

## What it blocks (HARD_DENY)

- `rm -rf` on `/`, `~`, `$HOME`, `--no-preserve-root`, system paths (`/etc`, `/usr`, `/var`, `/boot`, `/sys`, `/proc`, `/bin`, `/sbin`, `/lib`, `/opt`, `/root`)
- Raw block-device writes (`dd`/`mkfs`/`wipefs`/`shred` to `/dev/sd*`/`/dev/nvme*`, redirection to block devices)
- `git push --force` / `-f` to a protected branch (`main`/`master`/`prod`/`production`) — but `--force-with-lease` short-circuits and is always allowed
- `DROP DATABASE`, `DROP TABLE`, `TRUNCATE TABLE`
- `kubectl delete namespace prod`/`production`/`kube-system`
- `aws s3 ... --recursive s3://`, `aws s3 rm --recursive`/`delete-bucket`
- Credential exfil: `cat ~/.ssh/id_rsa`, `cat ~/.aws/credentials`, `echo $AWS_SECRET...`
- `curl|wget ... | bash`
- `chmod +s` (setuid)

## What it soft-denies (with safer-alternative suggestions)

- `rm -rf` (CWD-scoped — only blocks when the path escapes `$CLAUDE_PROJECT_DIR` and isn't under `SAFE_PATH_PREFIXES`)
- `git clean -fd`
- `pkill -9`, `kill -9 1`

## Override token

Every deny message includes a token of the form `DG-OK-<6 hex>`. Re-issuing the same command with the token appended (e.g. in a comment) bypasses all checks for that single invocation and logs an `OVERRIDE` entry to `~/.claude/destructive-guard.log`.

## Files

**Created**
- `plugins/destructive-guard/.claude-plugin/plugin.json` — `PreToolUse`/`Bash` hook registration
- `plugins/destructive-guard/scripts/guard.sh` — hook script (fail-open, jq-parsed payload, `${CLAUDE_PLUGIN_ROOT}`-rooted rules path)
- `plugins/destructive-guard/scripts/rules.conf` — sectioned `regex|reason|category` ruleset with `[SETTINGS]`/`[HARD_DENY]`/`[SOFT_DENY]`/`[CWD_SCOPED]`
- `plugins/destructive-guard/skills/guard-setup/SKILL.md` — operator-facing tuning guide
- `plugins/destructive-guard/skills/guard-setup/evals/evals.json` — routing evals (5 positive, 2 negative)

**Modified**
- `.claude-plugin/marketplace.json` — registered new plugin entry
- `Makefile` — appended to `PLUGINS` list
- `scripts/init.sh` — added `plugin.json` to `FILES_TO_REPLACE`

## Test plan

- [x] Smoke-tested guard.sh against 21 inputs covering allow / HARD / SOFT / cwd-scoped / override-token / `--force-with-lease` short-circuit
- [x] Verified `~/.claude/destructive-guard.log` records HARD/SOFT/OVERRIDE rows
- [ ] `make cme-coverage` / `make cme-overlap` (to be run by CI)
- [ ] Local `make install-local` smoke test on a real Claude Code session

## Notable implementation details

- Rule lines are parsed by stripping the trailing `|reason|category` from the right (`${line##*|}` / `${line%|*}`), so regex patterns may freely contain `|` for alternation.
- The `git-force` category triggers a `--force-with-lease` short-circuit before the regex is evaluated, avoiding the need for PCRE negative lookahead.
- Settings (`OVERRIDE_TOKEN_PATTERN`, `PROTECTED_BRANCHES`, `PROTECTED_NAMESPACES`, `SAFE_PATH_PREFIXES`) are read from the `[SETTINGS]` section by an awk extractor; branches/namespaces are interpolated into rules wherever `__PROTECTED_BRANCHES__` / `__PROTECTED_NAMESPACES__` appears.
- `trap 'exit 0' ERR` plus `set -u` (no `-e`) and `2>/dev/null || true` on every external call enforces fail-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)